### PR TITLE
chore: apply purple and yellow theme

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -24,49 +24,48 @@
   /* gradient */
 
   --bg-gradient-onyx: linear-gradient(
-    to bottom right, 
-    hsl(240, 1%, 25%) 3%, 
-    hsl(0, 0%, 19%) 97%
+    to bottom right,
+    #4e1873 3%,
+    #3e165e 97%
   );
   --bg-gradient-jet: linear-gradient(
-    to bottom right, 
-    hsla(240, 1%, 18%, 0.251) 0%, 
-    hsla(240, 2%, 11%, 0) 100%
-  ), hsl(240, 2%, 13%);
+    to bottom right,
+    rgba(78, 24, 115, 0.251) 0%,
+    rgba(62, 22, 94, 0) 100%
+  ), #3e165e;
   --bg-gradient-yellow-1: linear-gradient(
-    to bottom right, 
-    hsl(45, 100%, 71%) 0%, 
-    hsla(36, 100%, 69%, 0) 50%
+    to bottom right,
+    #F8B200 0%,
+    rgba(248, 178, 0, 0) 50%
   );
   --bg-gradient-yellow-2: linear-gradient(
-    135deg, 
-    hsla(45, 100%, 71%, 0.251) 0%, 
-    hsla(35, 100%, 68%, 0) 59.86%
-  ), hsl(240, 2%, 13%);
+    135deg,
+    rgba(248, 178, 0, 0.251) 0%,
+    rgba(248, 178, 0, 0) 59.86%
+  ), #561D82;
   --border-gradient-onyx: linear-gradient(
-    to bottom right, 
-    hsl(0, 0%, 25%) 0%, 
-    hsla(0, 0%, 25%, 0) 50%
+    to bottom right,
+    #3e165e 0%,
+    rgba(62, 22, 94, 0) 50%
   );
   --text-gradient-yellow: linear-gradient(
-    to right, 
-    hsl(45, 100%, 72%), 
-    hsl(35, 100%, 68%)
+    to right,
+    #F8B200,
+    #DFA100
   );
 
   /* solid */
 
-  --jet: hsl(0, 0%, 22%);
-  --onyx: hsl(240, 1%, 17%);
-  --eerie-black-1: hsl(240, 2%, 13%);
-  --eerie-black-2: hsl(240, 2%, 12%);
-  --smoky-black: hsl(0, 0%, 7%);
-  --white-1: hsl(0, 0%, 100%);
-  --white-2: hsl(0, 0%, 98%);
-  --orange-yellow-crayola: hsl(45, 100%, 72%);
-  --vegas-gold: hsl(45, 54%, 58%);
-  --light-gray: hsl(0, 0%, 84%);
-  --light-gray-70: hsla(0, 0%, 84%, 0.7);
+  --jet: #3e165e;
+  --onyx: #561D82;
+  --eerie-black-1: #4e1873;
+  --eerie-black-2: #4e1873;
+  --smoky-black: #561D82;
+  --white-1: #ffffff;
+  --white-2: #ffffff;
+  --orange-yellow-crayola: #F8B200;
+  --light-gray: #ffffff;
+  --light-gray-70: rgba(255, 255, 255, 0.7);
   --bittersweet-shimmer: hsl(0, 43%, 51%);
 
   /**
@@ -148,7 +147,7 @@ input, textarea {
 
 ::selection {
   background: var(--orange-yellow-crayola);
-  color: var(--smoky-black);
+  color: var(--white-1);
 }
 
 :focus { outline-color: var(--orange-yellow-crayola); }
@@ -459,7 +458,7 @@ main {
   bottom: 0;
   left: 0;
   width: 100%;
-  background: hsla(240, 1%, 17%, 0.75);
+  background: rgba(78, 24, 115, 0.75);
   backdrop-filter: blur(10px);
   border: 1px solid var(--jet);
   border-radius: 12px 12px 0 0;
@@ -641,7 +640,7 @@ main {
   left: 0;
   width: 100%;
   height: 100vh;
-  background: hsl(0, 0%, 5%);
+  background: rgba(62, 22, 94, 0.8);
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
@@ -796,7 +795,7 @@ main {
 }
 
 .timeline-list span {
-  color: var(--vegas-gold);
+  color: var(--white-1);
   font-weight: var(--fw-400);
   line-height: 1.6;
 }
@@ -930,7 +929,7 @@ main {
   border-radius: 8px;
 }
 
-.select-item button:hover { --eerie-black-2: hsl(240, 2%, 20%); }
+.select-item button:hover { --eerie-black-2: #3e165e; }
 
 .project-list {
   display: grid;
@@ -974,7 +973,7 @@ main {
   transition: var(--transition-1);
 }
 
-.project-item > a:hover .project-img::before { background: hsla(0, 0%, 0%, 0.5); }
+.project-item > a:hover .project-img::before { background: rgba(62, 22, 94, 0.5); }
 
 .project-item-icon-box {
   --scale: 0.8;


### PR DESCRIPTION
## Summary
- restyled color variables to purple `#561D82` and yellow `#F8B200`
- ensured text stays white and updated overlays and navbar for the new palette

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b31b858e7083209aab568975f48523