### PR TITLE
Fix portfolio filters for Portuguese categories

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -32,11 +32,23 @@ const selectItems = document.querySelectorAll("[data-select-item]");
 const selectValue = document.querySelector("[data-selecct-value]"); // manter igual ao HTML
 const filterBtn = document.querySelectorAll("[data-filter-btn]");
 
-// Normalizador simples para aceitar "all" ou "todos"
+// Normalizador simples para aceitar categorias em português e inglês
 const normalizeSelection = (txt) => {
     const v = (txt || "").toLowerCase().trim();
-    if (v === "todos") return "all";
-    return v;
+
+    // Mapeamentos de categorias traduzidas para os valores de data-category
+    const map = {
+        "todos": "all",
+        "all": "all",
+        "design web": "web design",
+        "web design": "web design",
+        "aplicativos": "applications",
+        "applications": "applications",
+        "desenvolvimento web": "web development",
+        "web development": "web development",
+    };
+
+    return map[v] || v;
 };
 
 if (select) {


### PR DESCRIPTION
## Summary
- ensure portfolio filters work with Portuguese category names by mapping them to data-category values

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b31d0c2f5c8320ab100476b47393b6