### PR TITLE
Reorganize skills section for clarity

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -866,6 +866,19 @@ main {
   border-radius: inherit;
 }
 
+/* tools icons */
+
+.dev-icons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 15px;
+  padding: 20px;
+}
+
+.dev-icons .icon-box {
+  font-size: 24px;
+}
+
 
 
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 
     <link rel="shortcut icon" href="./assets/images/logo.ico" type="image/x-icon">
     <link rel="stylesheet" href="./assets/css/style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -245,7 +246,7 @@
 
                 <section class="skill">
                     <h3 class="h3 skills-title">Minhas habilidades</h3>
-                    <div class="subheading mb-3">Fluxo de Trabalho</div>
+                    <h4 class="h4">Fluxo de Trabalho</h4>
                     <ul class="skills-list content-card">
                         <li class="skills-item">
                             <div class="title-wrapper">
@@ -293,9 +294,7 @@
                         </li>
                     </ul>
 
-                    <div class="subheading mb-3">
-                        Ferramentas e Linguagens de Programação
-                    </div>
+                    <h4 class="h4">Ferramentas e Linguagens de Programação</h4>
                     <ul class="list-inline dev-icons">
                         <li class="list-inline-item"><i class="fab fa-html5"></i></li>
                         <li class="list-inline-item"><i class="fab fa-css3-alt"></i></li>

--- a/index.html
+++ b/index.html
@@ -295,18 +295,18 @@
                     </ul>
 
                     <h4 class="h4">Ferramentas e Linguagens de Programação</h4>
-                    <ul class="list-inline dev-icons">
-                        <li class="list-inline-item"><i class="fab fa-html5"></i></li>
-                        <li class="list-inline-item"><i class="fab fa-css3-alt"></i></li>
-                        <li class="list-inline-item"><i class="fab fa-js-square"></i></li>
-                        <li class="list-inline-item"><i class="fab fa-node-js"></i></li>
-                        <li class="list-inline-item"><i class="fab fa-npm"></i></li>
-                        <li class="list-inline-item"><i class="fab fa-react"></i></li>
-                        <li class="list-inline-item"><i class="fab fa-bootstrap"></i></li>
-                        <li class="list-inline-item"><i class="fas fa-database"></i></li>
-                        <li class="list-inline-item"><i class="fab fa-figma"></i></li>
-                        <li class="list-inline-item"><i class="fab fa-git-alt"></i></li>
-                        <li class="list-inline-item"><i class="fab fa-github"></i></li>
+                    <ul class="dev-icons">
+                        <li class="icon-box"><i class="fab fa-html5"></i></li>
+                        <li class="icon-box"><i class="fab fa-css3-alt"></i></li>
+                        <li class="icon-box"><i class="fab fa-js-square"></i></li>
+                        <li class="icon-box"><i class="fab fa-node-js"></i></li>
+                        <li class="icon-box"><i class="fab fa-npm"></i></li>
+                        <li class="icon-box"><i class="fab fa-react"></i></li>
+                        <li class="icon-box"><i class="fab fa-bootstrap"></i></li>
+                        <li class="icon-box"><i class="fas fa-database"></i></li>
+                        <li class="icon-box"><i class="fab fa-figma"></i></li>
+                        <li class="icon-box"><i class="fab fa-git-alt"></i></li>
+                        <li class="icon-box"><i class="fab fa-github"></i></li>
                     </ul>
                 </section>
         </article>

--- a/index.html
+++ b/index.html
@@ -245,8 +245,8 @@
 
                 <section class="skill">
                     <h3 class="h3 skills-title">Minhas habilidades</h3>
+                    <div class="subheading mb-3">Fluxo de Trabalho</div>
                     <ul class="skills-list content-card">
-                        <div class="subheading mb-3">Fluxo de Trabalho</div>
                         <li class="skills-item">
                             <div class="title-wrapper">
                                 <h5 class="h5">Fronted Web</h5><data value="80">80%</data>
@@ -292,24 +292,24 @@
                             </div>
                         </li>
                     </ul>
-        </div>
-        <div class="subheading mb-3">
-            Ferramentas e Linguagens de Programação
-        </div>
-        <ul class="list-inline dev-icons">
-            <li class="list-inline-item"><i class="fab fa-html5"></i></li>
-            <li class="list-inline-item"><i class="fab fa-css3-alt"></i></li>
-            <li class="list-inline-item"><i class="fab fa-js-square"></i></li>
-            <li class="list-inline-item"><i class="fab fa-node-js"></i></li>
-            <li class="list-inline-item"><i class="fab fa-npm"></i></li>
-            <li class="list-inline-item"><i class="fab fa-react"></i></li>
-            <li class="list-inline-item"><i class="fab fa-bootstrap"></i></li>
-            <li class="list-inline-item"><i class="fas fa-database"></i></li>
-            <li class="list-inline-item"><i class="fab fa-figma"></i></li>
-            <li class="list-inline-item"><i class="fab fa-git-alt"></i></li>
-            <li class="list-inline-item"><i class="fab fa-github"></i></li>
-        </ul>
-        </section>
+
+                    <div class="subheading mb-3">
+                        Ferramentas e Linguagens de Programação
+                    </div>
+                    <ul class="list-inline dev-icons">
+                        <li class="list-inline-item"><i class="fab fa-html5"></i></li>
+                        <li class="list-inline-item"><i class="fab fa-css3-alt"></i></li>
+                        <li class="list-inline-item"><i class="fab fa-js-square"></i></li>
+                        <li class="list-inline-item"><i class="fab fa-node-js"></i></li>
+                        <li class="list-inline-item"><i class="fab fa-npm"></i></li>
+                        <li class="list-inline-item"><i class="fab fa-react"></i></li>
+                        <li class="list-inline-item"><i class="fab fa-bootstrap"></i></li>
+                        <li class="list-inline-item"><i class="fas fa-database"></i></li>
+                        <li class="list-inline-item"><i class="fab fa-figma"></i></li>
+                        <li class="list-inline-item"><i class="fab fa-git-alt"></i></li>
+                        <li class="list-inline-item"><i class="fab fa-github"></i></li>
+                    </ul>
+                </section>
         </article>
 
         <!-- PORTFOLIO -->


### PR DESCRIPTION
## Summary
- restructure resume skills section to move headings outside lists
- remove stray closing tags and group tools listing clearly

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b32287279083208abe180f7f974f0d